### PR TITLE
Dev jrl features02

### DIFF
--- a/.github/workflows/RQB-image-v2.yaml
+++ b/.github/workflows/RQB-image-v2.yaml
@@ -766,7 +766,7 @@ jobs:
           # Extract temporarily to calculate uncompressed metadata
           echo "Extracting compressed image temporarily for metadata calculation..."
           TEMP_IMG_FILE="${XZ_FILE_DEPLOY%.xz}"
-          xz -d -k "$XZ_FILE_DEPLOY"
+          sudo xz -d -k "$XZ_FILE_DEPLOY"
           IMG_FILE="$TEMP_IMG_FILE"
           
           # Find the compressed image file  

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-dev-JRL-features02-2025-06-05-060357
+dev-JRL-features02-2025-06-17-134430

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-dev-JRL-features02-2025-06-17-134430
+dev-JRL-features02-2025-06-17-152059


### PR DESCRIPTION
There was an issue where trying to compute the size of the image. The following error was thrown:
Extracting compressed image temporarily for metadata calculation...
xz: deploy/image_2025-06-17-rasqberry.img: Permission denied

I modified the function to use sudo instead:

TEMP_IMG_FILE="${XZ_FILE_DEPLOY%.xz}"
          sudo xz -d -k "$XZ_FILE_DEPLOY"
          IMG_FILE="$TEMP_IMG_FILE"

This then worked.