### PR TITLE
feat(workflow): add ARM64 runners and build scope options

### DIFF
--- a/.github/workflows/RQB-image-v2.yaml
+++ b/.github/workflows/RQB-image-v2.yaml
@@ -10,6 +10,7 @@
 # - Automatic GitHub releases with built images
 # - Memory and disk optimization for GitHub Actions runners
 # - Support for both development and production builds
+# - A/B boot images for over-the-air updates
 #
 # Trigger Conditions:
 # - Manual workflow dispatch (with optional version override)
@@ -48,20 +49,32 @@
 # ============================================================================
 # ENVIRONMENT VARIABLES REFERENCE
 # ============================================================================
+# Build configuration is split between workflow (CACHE_VERSION) and pi-gen-config.
+# The workflow reads from pi-gen-config and applies branch-specific logic.
 #
-# Custom Variables (from pi-gen-config):
-#   - CACHE_VERSION: Increment to invalidate all caches
-#   - RQB_*: RasQberry-specific build configuration
-#     - RQB_REPO: Repository name (set dynamically)
-#     - RQB_GIT_USER: GitHub username (set dynamically)
-#     - RQB_GIT_BRANCH: Branch to build from (set dynamically)
-#     - RQB_STD_VENV: Standard virtual environment name
-#     - RQB_CONFDIR: Configuration directory path
+# Workflow Variables (env section below):
+#    - CACHE_VERSION: GitHub Actions cache versioning
 #
-# Pi-gen Variables (from pi-gen-config):
-#   - FIRST_USER_NAME: Default user (rasqberry)
-#   - IMG_NAME: Output image name prefix
-#   - SKIP_INITRAMFS: Speed optimization flag
+# Pi-gen-config Variables (centralized configuration file):
+#
+# 1. Build Quality Settings:
+#    - COMPRESSION_LEVEL_DEV / COMPRESSION_LEVEL_PROD: Image compression (1 dev, 9 prod)
+#    - COMPRESSION_LEVEL_DEV_FALLBACK: Higher level if dev image exceeds 2GB (6)
+#    - SKIP_INITRAMFS / SKIP_INITRAMFS_PROD: Initramfs generation control
+#
+# 2. Console Configuration (read by workflow):
+#    - CONSOLE_TYPE / CONSOLE_TYPE_PROD / CONSOLE_TYPE_DEV: Console output (hdmi/serial)
+#    - BOOT_VERBOSITY / BOOT_VERBOSITY_PROD / BOOT_VERBOSITY_DEV: Boot output (splash/verbose)
+#
+# 3. RasQberry Configuration:
+#    - RQB_REPO, RQB_GIT_USER, RQB_GIT_BRANCH: Repository settings (set by workflow)
+#    - RQB_STD_VENV, RQB_PIGEN: Virtual environment settings
+#
+# 4. User & System Settings:
+#    - FIRST_USER_NAME, IMG_NAME: User and image naming
+#    - RELEASE, LOCALE_DEFAULT, TIMEZONE_DEFAULT: System configuration
+#
+# Data Flow: pi-gen-config → workflow reads/applies logic → pi-gen build
 # ============================================================================
 
 name: Rasqberry Pi Image Release v2
@@ -77,6 +90,7 @@ permissions:
   checks: write        # Update check status
   id-token: write      # Sign artifacts with cosign
   packages: write      # Push to GitHub container registry
+  actions: write       # Trigger consolidation workflow
 
 # ============================================================================
 # WORKFLOW TRIGGERS
@@ -89,47 +103,44 @@ on:
         description: 'Version number (required for main branch)'
         required: false
         type: string
-      refresh_cache:
-        description: 'Force cache refresh (dev branches only)'
-        required: false
-        type: boolean
-        default: false
-      build_cache:
-        description: 'Enable caching for main branch (to seed cross-branch cache)'
-        required: false
-        type: boolean
-        default: false
-      publish_json:
-        description: 'Publish generated JSON to gh-pages (JSON always created locally)'
-        required: false
-        type: boolean
-        default: false
       build_scope:
-        description: 'Build scope (default: dev=full, main/beta=standard-image)'
+        description: 'What to build (default: dev=ab-only, main/beta=full)'
         required: false
         default: 'default'
         type: choice
         options:
           - default
           - cache-only
+          - ab-only
           - standard-image
           - full
       console_type:
-        description: 'Console output type (serial or hdmi)'
+        description: 'Console output (default: dev=serial, main/beta=hdmi)'
         required: false
-        default: 'hdmi'
+        default: 'default'
         type: choice
         options:
+          - default
           - hdmi
           - serial
       boot_verbosity:
-        description: 'Boot output verbosity (verbose or splash)'
+        description: 'Boot verbosity (default: dev=verbose, main/beta=splash)'
         required: false
-        default: 'splash'
+        default: 'default'
         type: choice
         options:
+          - default
           - verbose
           - splash
+      runner_type:
+        description: 'Runner architecture (default=arm64 native, x64=QEMU emulated)'
+        required: false
+        default: 'default'
+        type: choice
+        options:
+          - default
+          - arm64
+          - x64
 
   # Automatic trigger for development branches
   push:
@@ -262,11 +273,11 @@ jobs:
           if [ "$INPUT_SCOPE" == "default" ] || [ -z "$INPUT_SCOPE" ]; then
             # Apply branch-based defaults
             if [[ "$BRANCH_NAME" == dev* ]]; then
-              SCOPE="full"
-              echo "Using default scope for dev branch: full"
+              SCOPE="ab-only"
+              echo "Using default scope for dev branch: ab-only (A/B image only)"
             else
-              SCOPE="standard-image"
-              echo "Using default scope for $BRANCH_NAME branch: standard-image"
+              SCOPE="full"
+              echo "Using default scope for $BRANCH_NAME branch: full (both images)"
             fi
           else
             SCOPE="$INPUT_SCOPE"
@@ -307,12 +318,23 @@ jobs:
           ref: ${{ needs.rasqberry-push-version-number.outputs.commit_sha }}
           fetch-depth: 0  # Full history needed for git-cliff
 
-      # Get the most recent tag for changelog generation
-      - name: Get latest tag
+      # Get the previous tag (skip the tag we just created) for changelog generation
+      # Filter by branch name to avoid picking tags from other branches
+      - name: Get previous tag
         id: latest_tag
         shell: bash
         run: |
-          echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+
+          # For main branch, look for v* tags; for dev branches, look for branch-* tags
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            PREV_TAG=$(git tag --sort=-creatordate | grep '^v' | sed -n '2p')
+          else
+            PREV_TAG=$(git tag --sort=-creatordate | grep "^${BRANCH_NAME}-" | sed -n '2p')
+          fi
+
+          echo "TAG_NAME=${PREV_TAG}" >> $GITHUB_OUTPUT
+          echo "Found previous tag: ${PREV_TAG}"
 
       # Generate changelog from commits since last tag
       - name: Generate a changelog
@@ -328,7 +350,7 @@ jobs:
       # - Dev: "rasqberry-dev-2024-01-01-123456"
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@v2.4.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ github.ref == 'refs/heads/main' && format('rasqberry-v{0}', needs.rasqberry-push-version-number.outputs.version_num) || format('rasqberry-{0}', needs.rasqberry-push-version-number.outputs.version_num) }}
@@ -344,17 +366,23 @@ jobs:
   # ============================================================================
   # This job builds the actual Raspberry Pi OS image using pi-gen
   # Includes sophisticated caching for development builds
-  # For cache-only builds: builds and caches base stages only, no image output
+  # For cache-only builds: builds base stages + downloads ARM64 wheels, no image output
   build:
     name: Build Image
     needs: [rasqberry-push-version-number, release]
     # For cache-only, release is skipped but we still need version info
     if: always() && needs.rasqberry-push-version-number.result == 'success'
-    runs-on: ubuntu-latest
+    # Runner selection: arm64=native (default), x64=emulated (QEMU)
+    # ARM64 native runners are free for public repos since Jan 2025
+    runs-on: ${{ github.event.inputs.runner_type == 'x64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     outputs:
       # Output paths for the built image
       asset_path: ${{ steps.set-asset.outputs.asset_path }}
       asset_name: ${{ steps.set-asset.outputs.asset_name }}
+      # Pre-computed metadata (saves ~2min by avoiding re-download in JSON job)
+      extract_sha256: ${{ steps.set-asset.outputs.extract_sha256 }}
+      extract_size: ${{ steps.set-asset.outputs.extract_size }}
+      compressed_size: ${{ steps.set-asset.outputs.compressed_size }}
 
     steps:
       # Checkout the commit with updated VERSION file from Job 1
@@ -363,96 +391,111 @@ jobs:
         with:
           ref: ${{ needs.rasqberry-push-version-number.outputs.commit_sha }}
 
+      # Brief configuration summary at start of build
+      - name: Build configuration
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+
+          # Determine stream type
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "beta" ]]; then
+            STREAM="prod"
+            CONSOLE=$(grep "^CONSOLE_TYPE_PROD=" pi-gen-config | cut -d'=' -f2)
+            VERBOSITY=$(grep "^BOOT_VERBOSITY_PROD=" pi-gen-config | cut -d'=' -f2)
+            COMPRESS=$(grep "^COMPRESSION_LEVEL_PROD=" pi-gen-config | cut -d'=' -f2)
+          else
+            STREAM="dev"
+            CONSOLE=$(grep "^CONSOLE_TYPE_DEV=" pi-gen-config | cut -d'=' -f2)
+            VERBOSITY=$(grep "^BOOT_VERBOSITY_DEV=" pi-gen-config | cut -d'=' -f2)
+            COMPRESS=$(grep "^COMPRESSION_LEVEL_DEV=" pi-gen-config | cut -d'=' -f2)
+          fi
+
+          echo "========================================"
+          echo "BUILD CONFIGURATION"
+          echo "========================================"
+          echo "Branch: $BRANCH"
+          echo "Commit: ${{ needs.rasqberry-push-version-number.outputs.commit_sha }}"
+          echo "Version: ${{ needs.rasqberry-push-version-number.outputs.version_num }}"
+          echo ""
+          echo "Runner: ${{ runner.os }} / ${{ runner.arch }}"
+          echo "Trigger: ${{ github.event_name }}"
+          echo "Build scope: ${{ needs.rasqberry-push-version-number.outputs.build_scope }}"
+          echo ""
+          echo "Stream: $STREAM"
+          echo "Console: $CONSOLE"
+          echo "Boot verbosity: $VERBOSITY"
+          echo "Compression: xz -$COMPRESS"
+          echo "Cache version: ${{ env.CACHE_VERSION }}"
+          echo "========================================"
+          echo ""
+
       # ========================================================================
       # DISK SPACE OPTIMIZATION
       # ========================================================================
-      # GitHub Actions runners have limited disk space (~14GB free)
-      # Pi-gen needs significant space for building images
+      # GitHub Actions runners have limited disk space
+      # ARM64: ~46GB free (fewer pre-installed tools)
+      # x86:   ~14GB free (many pre-installed tools)
       - name: Free up disk space
         run: |
-          echo "=== Initial disk space ==="
+          ARCH=$(uname -m)
+          echo "=== Initial disk space (arch: $ARCH) ==="
           df -h /
 
-          # Get available space in GB with decimal precision
           get_available_gb() {
             df / | awk 'NR==2 {printf "%.1f", $4/1024/1024}'
           }
 
-          # Parallel cleanup - all operations run simultaneously
-          echo "Starting parallel disk cleanup..."
           before=$(get_available_gb)
           start=$(date +%s)
 
-          # Launch all directory removals in parallel
-          (
-            if [ -d "/opt/hostedtoolcache" ]; then
-              echo "Removing tool-cache..."
-              sudo rm -rf "/opt/hostedtoolcache"
-              echo "  ✓ tool-cache removed"
-            fi
-          ) &
+          # Architecture-specific cleanup
+          # ARM64 runners have fewer pre-installed tools, so we skip non-existent items
+          case "$ARCH" in
+            aarch64|arm64)
+              echo "ARM64: Optimized cleanup..."
+              # Show largest directories for diagnostics (helps identify new cleanup targets)
+              echo "Top 15 largest directories:"
+              sudo du -h --max-depth=2 /usr /opt 2>/dev/null | sort -rh | head -15 || true
 
-          (
-            if [ -d "/usr/local/lib/android" ]; then
-              echo "Removing android..."
-              sudo rm -rf "/usr/local/lib/android"
-              echo "  ✓ android removed"
-            fi
-          ) &
+              # Directories confirmed to exist on ARM64 runners:
+              sudo rm -rf /opt/hostedtoolcache &   # ~500MB tool cache
+              sudo rm -rf /usr/share/dotnet &      # ~2GB .NET SDK
+              sudo rm -rf /usr/share/swift &       # ~1.5GB Swift toolchain
+              sudo rm -rf /usr/local/julia* &      # ~500MB Julia
+              sudo rm -rf /usr/share/miniconda &   # ~400MB Miniconda
+              sudo rm -rf /usr/local/aws-cli &     # ~200MB AWS CLI
+              sudo rm -rf /imagegeneration &       # Runner provisioning artifacts
+              sudo rm -rf /opt/pipx &              # pipx installations
+              # Skip: android, ghc, ghcup, boost (not installed on ARM64)
+              # Skip: apt-get remove (packages not installed, wastes 14s)
+              ;;
+            *)
+              echo "x86: Full cleanup..."
+              # All these exist on x86 runners:
+              sudo rm -rf /opt/hostedtoolcache &
+              sudo rm -rf /usr/local/lib/android &
+              sudo rm -rf /usr/share/dotnet &
+              sudo rm -rf /opt/ghc &
+              sudo rm -rf /usr/local/.ghcup &
+              sudo rm -rf /usr/local/share/boost &
+              sudo rm -rf /usr/share/swift &
+              sudo rm -rf /usr/local/julia* &
+              sudo rm -rf /usr/share/miniconda &
+              sudo rm -rf /imagegeneration &
+              # apt-get remove (useful on x86, many packages installed)
+              (
+                sudo apt-get remove -y '^aspnetcore-.*' '^dotnet-.*' 'php.*' '^mongodb-.*' '^mysql-.*' azure-cli google-chrome-stable firefox powershell mono-devel 2>/dev/null || true
+                sudo apt-get autoremove -y 2>/dev/null || true
+              ) &
+              ;;
+          esac
 
-          (
-            if [ -d "/usr/share/dotnet" ]; then
-              echo "Removing dotnet..."
-              sudo rm -rf "/usr/share/dotnet"
-              echo "  ✓ dotnet removed"
-            fi
-          ) &
-
-          (
-            if [ -d "/opt/ghc" ]; then
-              echo "Removing haskell..."
-              sudo rm -rf "/opt/ghc"
-              echo "  ✓ haskell removed"
-            fi
-          ) &
-
-          (
-            if [ -d "/usr/local/.ghcup" ]; then
-              echo "Removing ghcup..."
-              sudo rm -rf "/usr/local/.ghcup"
-              echo "  ✓ ghcup removed"
-            fi
-          ) &
-
-          (
-            if [ -d "/usr/local/share/boost" ]; then
-              echo "Removing boost..."
-              sudo rm -rf "/usr/local/share/boost"
-              echo "  ✓ boost removed"
-            fi
-          ) &
-
-          # Run apt-get cleanup in parallel too
-          (
-            echo "Removing large packages..."
-            sudo apt-get remove -y '^aspnetcore-.*' '^dotnet-.*' 'php.*' '^mongodb-.*' '^mysql-.*' azure-cli google-chrome-stable firefox powershell mono-devel 2>/dev/null || true
-            sudo apt-get autoremove -y 2>/dev/null || true
-            echo "  ✓ apt-get cleanup completed"
-          ) &
-
-          # Wait for all parallel operations to complete
           wait
 
-          # Measure final state
           end=$(date +%s)
           after=$(get_available_gb)
           freed=$(echo "scale=1; $after - $before" | bc)
           echo ""
-          echo "=== Parallel cleanup results ==="
-          echo "  ✓ All cleanup completed in $((end - start))s - freed ${freed}GB"
-
-          echo ""
-          echo "=== Final disk space ==="
+          echo "=== Cleanup complete: ${freed}GB freed in $((end - start))s ==="
           df -h /
 
       # ========================================================================
@@ -462,24 +505,29 @@ jobs:
       # Create large swap file to prevent OOM errors
       - name: Maximize available memory
         run: |
-          echo "=== Initial memory status ==="
+          ARCH=$(uname -m)
+          echo "=== Initial memory status (arch: $ARCH) ==="
           free -h
-          
+
           # Stop unnecessary services to free RAM
+          # ARM64 has fewer services installed, so we only stop what exists
           echo "Stopping unnecessary services..."
-          sudo systemctl stop mysql || true
-          sudo systemctl stop postgresql || true
-          sudo systemctl stop apache2 || true
-          sudo systemctl stop snapd || true
-          sudo systemctl stop google-chrome || true
-          sudo systemctl stop firefox || true
-          sudo systemctl stop dotnet || true
-          
-          # Remove existing swap
+          case "$ARCH" in
+            aarch64|arm64)
+              # Only these services exist on ARM64 runners:
+              sudo systemctl stop mysql snapd 2>/dev/null || true
+              # Skip: postgresql, apache2, google-chrome, firefox, dotnet (not installed)
+              ;;
+            *)
+              # x86 has more services installed:
+              sudo systemctl stop mysql postgresql apache2 snapd google-chrome firefox dotnet 2>/dev/null || true
+              ;;
+          esac
+
+          # Remove existing swap and create larger one
           sudo swapoff -a || true
           sudo rm -f /swapfile || true
-          
-          # Create larger swap file (10GB)
+
           echo "Creating 10GB swap file..."
           sudo fallocate -l 10G /swapfile
           sudo chmod 600 /swapfile
@@ -498,52 +546,43 @@ jobs:
       - name: List available caches
         run: |
           echo "Current branch: ${GITHUB_REF#refs/heads/}"
-          echo "Cache key pattern: stage4-${{ env.CACHE_VERSION }}-$(date +"%Y-%m")-bookworm-arm64"
-          # Note: Can't actually list caches, but shows the key format
+          echo "Cache key pattern: stage4-v2-$(date +"%Y-%m")-bookworm-arm64"
+          # Note: Cache version defined in pi-gen-config (CACHE_VERSION)
 
       # Determine if this build should use caching
       # Rules:
-      # - Main branch: Cache disabled by default, enabled with build_cache input
-      # - Beta branch: Cache always disabled (production builds always fresh)
+      # - cache-only scope: Always use cache (rebuilding it)
+      # - Main/beta branches: Cache disabled (production builds always fresh)
       # - Dev branches: Cache enabled for faster development
-      # - Manual refresh_cache input forces fresh build
       - name: Determine if caching should be used
         id: cache-decision
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          FORCE_REFRESH="${{ github.event.inputs.refresh_cache }}"
-          BUILD_CACHE="${{ github.event.inputs.build_cache }}"
-          
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            if [ "$BUILD_CACHE" == "true" ]; then
-              echo "use_cache=true" >> $GITHUB_OUTPUT
-              echo "Cache enabled for main branch (manual override - will seed cross-branch cache)"
-            else
-              echo "use_cache=false" >> $GITHUB_OUTPUT
-              echo "Cache disabled for main branch (production build - use build_cache input to enable)"
-            fi
-          elif [[ "$BRANCH_NAME" == "beta" ]]; then
+          BUILD_SCOPE="${{ needs.rasqberry-push-version-number.outputs.build_scope }}"
+
+          if [[ "$BUILD_SCOPE" == "cache-only" ]]; then
+            echo "use_cache=true" >> $GITHUB_OUTPUT
+            echo "Cache enabled for cache-only build scope"
+          elif [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == "beta" ]]; then
             echo "use_cache=false" >> $GITHUB_OUTPUT
             echo "Cache disabled for production branch: $BRANCH_NAME"
           else
-            if [ "$FORCE_REFRESH" == "true" ]; then
-              echo "use_cache=false" >> $GITHUB_OUTPUT
-              echo "Cache refresh forced by workflow input"
-            else
-              echo "use_cache=true" >> $GITHUB_OUTPUT
-              echo "Cache enabled for development branch: $BRANCH_NAME"
-            fi
+            echo "use_cache=true" >> $GITHUB_OUTPUT
+            echo "Cache enabled for development branch: $BRANCH_NAME"
           fi
 
-      # Generate cache key with monthly rotation
-      # This ensures caches are refreshed monthly for security updates
+      # Generate cache keys with time-based rotation
+      # Monthly for pip cache, weekly for wheel cache (faster refresh for dev)
       - name: Generate cache date
         id: cache-date
         if: steps.cache-decision.outputs.use_cache == 'true'
         run: |
-          # Use year-month for cache key to refresh monthly
+          # Use year-month for pip cache (monthly refresh)
           CACHE_DATE=$(date +"%Y-%m")
           echo "cache_date=${CACHE_DATE}" >> $GITHUB_OUTPUT
+          # Use year-week for wheel cache (weekly refresh)
+          CACHE_WEEK=$(date +"%Y-W%V")
+          echo "cache_week=${CACHE_WEEK}" >> $GITHUB_OUTPUT
 
       # ========================================================================
       # CACHE RESTORATION - Base Stages Only
@@ -560,43 +599,45 @@ jobs:
           restore-keys: |
             base-stages-${{ env.CACHE_VERSION }}-
 
-      # Cache frequently downloaded apt packages
-      - name: Cache apt packages
-        id: cache-apt
-        uses: actions/cache@v3
+      # Cache ARM64 wheel files for Qiskit installation (dev branches only)
+      # Stores actual .whl files for instant installation (no network queries)
+      # Weekly TTL ensures packages are refreshed regularly for security updates
+      # Note: main/beta branches skip this cache (use_cache=false) to always get latest
+      - name: Cache ARM64 wheels
+        id: cache-wheels
+        if: steps.cache-decision.outputs.use_cache == 'true'
+        uses: actions/cache@v4
         with:
-          path: ~/apt-cache
-          key: apt-packages-${{ runner.os }}-pigen-deps-v1
-          restore-keys: |
-            apt-packages-${{ runner.os }}-pigen-deps-
+          path: ~/wheel-cache
+          # No restore-keys: require exact match to prevent stale cache on requirements change
+          key: wheels-arm64-${{ steps.cache-date.outputs.cache_week }}-${{ hashFiles('RQB2-config/qiskit-requirements.txt') }}
+
+      # Cache pip HTTP responses as fallback for packages not in wheel cache
+      # Helps when new packages are added or wheel cache is partial
+      - name: Cache pip packages (fallback)
+        id: cache-pip
+        if: steps.cache-decision.outputs.use_cache == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/pip-cache
+          # No restore-keys: require exact match to prevent stale cache on requirements change
+          key: pip-qiskit-arm64-${{ steps.cache-date.outputs.cache_date }}-${{ hashFiles('RQB2-config/qiskit-requirements.txt') }}
           
       # ========================================================================
       # PI-GEN DEPENDENCIES
       # ========================================================================
       # Install required packages for running pi-gen
-      # Uses apt package caching to speed up repeated builds
       - name: Install pi-gen dependencies
         run: |
-          # Create cache directory for apt packages
-          mkdir -p ~/apt-cache
-          
-          # Configure apt to keep downloaded packages
-          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | sudo tee /etc/apt/apt.conf.d/01cache
-          
-          # Restore cached packages if available
-          if [ "${{ steps.cache-apt.outputs.cache-hit }}" == "true" ] && [ -n "$(ls -A ~/apt-cache/*.deb 2>/dev/null)" ]; then
-            echo "Restoring apt packages from cache..."
-            echo "Found $(ls ~/apt-cache/*.deb | wc -l) packages in cache"
-            sudo cp -n ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-          else
-            echo "No cache found or cache is empty"
-          fi
-          
-          # Update package lists
           sudo apt-get update
-          
+
+          # Detect architecture
+          ARCH=$(uname -m)
+          echo "Runner architecture: $ARCH"
+
           # Install pi-gen dependencies
-          # These are required for cross-compilation and image building
+          # Note: qemu-user-static is required even on ARM64 because pi-gen's
+          # build.sh checks for it as a dependency (though it won't be used on ARM64)
           sudo apt-get install -y \
             coreutils \
             quilt \
@@ -611,6 +652,7 @@ jobs:
             grep \
             rsync \
             xz-utils \
+            zstd \
             file \
             git \
             curl \
@@ -619,12 +661,12 @@ jobs:
             pigz \
             lz4 \
             arch-test
-          
-          # Save downloaded packages to cache
-          echo "Copying packages to cache directory..."
-          cp -v /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
-          echo "Cache now contains $(ls ~/apt-cache/*.deb 2>/dev/null | wc -l) packages"
-          echo "Cache size: $(du -sh ~/apt-cache | cut -f1)"
+
+          if [ "$ARCH" = "aarch64" ]; then
+            echo "ARM64 runner detected - qemu-user-static installed for pi-gen check but won't be used"
+          else
+            echo "x86_64 runner detected - qemu-user-static will be used for ARM emulation"
+          fi
 
       # Clone official Raspberry Pi image generator
       - name: Clone pi-gen
@@ -723,18 +765,36 @@ jobs:
           # Branch-specific quality settings override using config file values
           if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == "beta" ]]; then
             echo "Applying production build settings for: $BRANCH_NAME"
-            
+
             # Read production values from config file
             SKIP_INITRAMFS_PROD=$(grep "^SKIP_INITRAMFS_PROD=" pi-gen-config | cut -d'=' -f2)
+            COMPRESSION_FORMAT_PROD=$(grep "^COMPRESSION_FORMAT_PROD=" pi-gen-config | cut -d'=' -f2)
+            COMPRESSION_FORMAT_PROD="${COMPRESSION_FORMAT_PROD:-xz}"
             COMPRESSION_LEVEL_PROD=$(grep "^COMPRESSION_LEVEL_PROD=" pi-gen-config | cut -d'=' -f2)
-            
+            COMPRESSION_LEVEL_PROD="${COMPRESSION_LEVEL_PROD:-9}"
+
             # Apply production values
             sed -i "s/^SKIP_INITRAMFS=.*/SKIP_INITRAMFS=${SKIP_INITRAMFS_PROD}/" pi-gen-config
-            sed -i "s/^COMPRESSION_LEVEL=.*/COMPRESSION_LEVEL=${COMPRESSION_LEVEL_PROD}/" pi-gen-config
+            echo "COMPRESSION_FORMAT=${COMPRESSION_FORMAT_PROD}" >> "$GITHUB_ENV"
+            echo "COMPRESSION_LEVEL=${COMPRESSION_LEVEL_PROD}" >> "$GITHUB_ENV"
           else
             echo "Using development build settings for: $BRANCH_NAME"
-            # Keep existing dev values from config file
+            # Read dev compression format, level, and fallback level
+            COMPRESSION_FORMAT_DEV=$(grep "^COMPRESSION_FORMAT_DEV=" pi-gen-config | cut -d'=' -f2)
+            COMPRESSION_FORMAT_DEV="${COMPRESSION_FORMAT_DEV:-xz}"
+            COMPRESSION_LEVEL_DEV=$(grep "^COMPRESSION_LEVEL_DEV=" pi-gen-config | cut -d'=' -f2)
+            COMPRESSION_LEVEL_DEV="${COMPRESSION_LEVEL_DEV:-1}"
+            COMPRESSION_LEVEL_DEV_FALLBACK=$(grep "^COMPRESSION_LEVEL_DEV_FALLBACK=" pi-gen-config | cut -d'=' -f2)
+            COMPRESSION_LEVEL_DEV_FALLBACK="${COMPRESSION_LEVEL_DEV_FALLBACK:-6}"
+            echo "COMPRESSION_FORMAT=${COMPRESSION_FORMAT_DEV}" >> "$GITHUB_ENV"
+            echo "COMPRESSION_LEVEL=${COMPRESSION_LEVEL_DEV}" >> "$GITHUB_ENV"
+            echo "COMPRESSION_LEVEL_FALLBACK=${COMPRESSION_LEVEL_DEV_FALLBACK}" >> "$GITHUB_ENV"
           fi
+
+          # Disable pi-gen compression - we'll compress both images (standard + A/B) ourselves
+          # This enables building A/B image directly without download/decompress cycle
+          sed -i "s/^DEPLOY_COMPRESSION=.*/DEPLOY_COMPRESSION=none/" pi-gen-config
+          echo "Pi-gen compression disabled - workflow will compress images after A/B conversion"
           
           # Conditional Git variable update (only if placeholder present)
           if grep -q "will-be-set-in-gh-workflow" pi-gen-config; then
@@ -750,8 +810,30 @@ jobs:
           fi
 
           # Update console configuration from workflow inputs
-          CONSOLE_TYPE="${{ inputs.console_type || 'hdmi' }}"
-          BOOT_VERBOSITY="${{ inputs.boot_verbosity || 'splash' }}"
+          # Read branch-specific defaults from pi-gen-config
+          if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == "beta" ]]; then
+            CONSOLE_DEFAULT=$(grep "^CONSOLE_TYPE_PROD=" pi-gen-config | cut -d'=' -f2)
+            BOOT_DEFAULT=$(grep "^BOOT_VERBOSITY_PROD=" pi-gen-config | cut -d'=' -f2)
+          else
+            CONSOLE_DEFAULT=$(grep "^CONSOLE_TYPE_DEV=" pi-gen-config | cut -d'=' -f2)
+            BOOT_DEFAULT=$(grep "^BOOT_VERBOSITY_DEV=" pi-gen-config | cut -d'=' -f2)
+          fi
+
+          # Apply 'default' input: use branch-based defaults
+          # For dev: serial/verbose, For beta/main: hdmi/splash
+          CONSOLE_INPUT="${{ inputs.console_type }}"
+          BOOT_INPUT="${{ inputs.boot_verbosity }}"
+          if [ "$CONSOLE_INPUT" == "default" ] || [ -z "$CONSOLE_INPUT" ]; then
+            CONSOLE_TYPE="$CONSOLE_DEFAULT"
+          else
+            CONSOLE_TYPE="$CONSOLE_INPUT"
+          fi
+          if [ "$BOOT_INPUT" == "default" ] || [ -z "$BOOT_INPUT" ]; then
+            BOOT_VERBOSITY="$BOOT_DEFAULT"
+          else
+            BOOT_VERBOSITY="$BOOT_INPUT"
+          fi
+
           sed -i "s|^CONSOLE_TYPE=.*|CONSOLE_TYPE=${CONSOLE_TYPE}|" pi-gen-config
           sed -i "s|^BOOT_VERBOSITY=.*|BOOT_VERBOSITY=${BOOT_VERBOSITY}|" pi-gen-config
           echo "Console configuration: CONSOLE_TYPE=${CONSOLE_TYPE}, BOOT_VERBOSITY=${BOOT_VERBOSITY}"
@@ -800,7 +882,7 @@ jobs:
           # Show final configuration for verification
           echo "=== Final pi-gen-config settings ==="
           echo "Build Quality:"
-          grep -E "^(SKIP_INITRAMFS|COMPRESSION_LEVEL)=" pi-gen-config
+          grep -E "^(SKIP_INITRAMFS|DEPLOY_COMPRESSION)=" pi-gen-config
           echo "Image Filename:"
           grep "^IMG_FILENAME=" pi-gen-config
           echo "Git Configuration:"
@@ -907,7 +989,7 @@ jobs:
               # Verify stage4 rootfs exists in cache
               if [ ! -d "$WORK_DIR/stage4/rootfs" ]; then
                 echo "ERROR: stage4/rootfs missing from cache!"
-                echo "Cache appears incomplete. Use 'refresh_cache' option to rebuild."
+                echo "Cache appears incomplete. Use 'build_scope: cache-only' to rebuild."
                 exit 1
               fi
               
@@ -927,14 +1009,17 @@ jobs:
               # Update package lists in cached rootfs (may be stale)
               echo "Refreshing package lists in cached rootfs..."
               sudo chroot "$WORK_DIR_ABS/stage4/rootfs" apt-get update || echo "Warning: Failed to update package lists"
-              
+
+              # Note: Pip cache is now managed by stage-RQB2 scripts (00-run.sh, 01-run.sh, 02-run.sh)
+              # Stage scripts handle: restore cache → qiskit install → save cache → clean from image
+
             else
               echo "ERROR: No work directory found in cache!"
               exit 1
             fi
           else
             echo "Building custom stage on fresh base..."
-            
+
             # For fresh builds or no cache, continue from base build
             echo "CONTINUE=1" >> config
             echo 'STAGE_LIST="./stage-RQB2"' >> config
@@ -944,77 +1029,386 @@ jobs:
           echo "=== Final config file ==="
           cat config
           echo "========================"
-          
+
+          # Prepare wheel cache for build (copy to sudo-accessible location)
+          # Wheels provide instant installation without downloads
+          echo "=== Preparing wheel cache for build ==="
+          if [ -d ~/wheel-cache ] && [ -n "$(ls -A ~/wheel-cache 2>/dev/null)" ]; then
+            cp -r ~/wheel-cache ../wheel-cache-host
+            WHEEL_COUNT=$(find ../wheel-cache-host -name "*.whl" 2>/dev/null | wc -l || echo "0")
+            echo "Copied wheel cache to build directory: $(du -sh ../wheel-cache-host | cut -f1) ($WHEEL_COUNT wheels)"
+          else
+            echo "No wheel cache available (first build or cache miss)"
+            mkdir -p ../wheel-cache-host
+          fi
+
+          # Prepare pip cache for build (fallback for packages not in wheel cache)
+          echo "=== Preparing pip cache for build ==="
+          if [ -d ~/pip-cache ] && [ -n "$(ls -A ~/pip-cache 2>/dev/null)" ]; then
+            cp -r ~/pip-cache ../pip-cache-host
+            echo "Copied pip cache to build directory: $(du -sh ../pip-cache-host | cut -f1)"
+          else
+            echo "No pip cache available (first build or cache miss)"
+          fi
+
           # Build the custom RasQberry stage
           sudo ./build.sh
 
+          # Copy updated wheel cache back to GitHub Actions location
+          echo "=== Saving updated wheel cache ==="
+          if [ -d ../wheel-cache-host ] && [ -n "$(ls -A ../wheel-cache-host 2>/dev/null)" ]; then
+            rm -rf ~/wheel-cache
+            cp -r ../wheel-cache-host ~/wheel-cache
+            WHEEL_COUNT=$(find ~/wheel-cache -name "*.whl" 2>/dev/null | wc -l || echo "0")
+            CACHE_SIZE=$(du -sh ~/wheel-cache 2>/dev/null | cut -f1 || echo "0")
+            echo "Updated wheel cache: $CACHE_SIZE ($WHEEL_COUNT wheels)"
+          else
+            echo "No wheel cache to save"
+          fi
+
+          # Copy updated pip cache back to GitHub Actions location
+          echo "=== Saving updated pip cache ==="
+          if [ -d ../pip-cache-host ] && [ -n "$(ls -A ../pip-cache-host 2>/dev/null)" ]; then
+            rm -rf ~/pip-cache
+            cp -r ../pip-cache-host ~/pip-cache
+            CACHE_SIZE=$(du -sh ~/pip-cache 2>/dev/null | cut -f1 || echo "0")
+            CACHE_FILES=$(find ~/pip-cache -type f 2>/dev/null | wc -l || echo "0")
+            echo "Updated pip cache: $CACHE_SIZE ($CACHE_FILES files)"
+          else
+            echo "No pip cache to save"
+          fi
+
+      # Note: Caches are managed by workflow + stage scripts:
+      #   Workflow: Copies ~/wheel-cache and ~/pip-cache to host dirs (before build)
+      #   00-run.sh: Restores wheel cache to /tmp/wheels in rootfs
+      #   00-run-chroot.sh: Installs qiskit using --find-links=/tmp/wheels
+      #   01-run.sh: Saves new wheels back to host, saves pip cache
+      #   02-run.sh: Cleans caches from rootfs (reduces image size)
+      #   Workflow: Copies host caches back to ~/ (after build)
+      # actions/cache@v4 persists both caches to GitHub Actions cache
+
       # ========================================================================
-      # IMAGE FINALIZATION
+      # CACHE-ONLY: DOWNLOAD WHEELS (no pi-gen build needed)
       # ========================================================================
-      # Find the built image and prepare it for upload
+      # For cache-only builds, download ARM64 wheels directly without running pi-gen
+      # This populates the wheel cache for cross-branch sharing
+      - name: Download ARM64 wheels for cache
+        if: needs.rasqberry-push-version-number.outputs.build_scope == 'cache-only'
+        run: |
+          echo "=== Downloading ARM64 wheels for cache ==="
+
+          # Create wheel cache directory
+          mkdir -p ~/wheel-cache
+
+          # Filter out packages without ARM64 wheels (netifaces) - built from source during install
+          grep -v '^netifaces' RQB2-config/qiskit-requirements.txt > /tmp/requirements-wheels.txt
+
+          # Download wheels for ARM64 (linux_aarch64)
+          # Uses --only-binary to skip packages that need compilation
+          pip download \
+            --dest ~/wheel-cache \
+            --platform linux_aarch64 \
+            --python-version 3.11 \
+            --implementation cp \
+            --abi cp311 \
+            --only-binary :all: \
+            -r /tmp/requirements-wheels.txt \
+            "qiskit[all]" || echo "Warning: Some packages may not have ARM64 wheels"
+
+          rm -f /tmp/requirements-wheels.txt
+
+          # Count and report
+          WHEEL_COUNT=$(find ~/wheel-cache -name "*.whl" 2>/dev/null | wc -l || echo "0")
+          CACHE_SIZE=$(du -sh ~/wheel-cache 2>/dev/null | cut -f1 || echo "0")
+          echo "Downloaded $WHEEL_COUNT wheels ($CACHE_SIZE)"
+
+          # List wheels for verification
+          echo "=== Downloaded wheels ==="
+          ls -la ~/wheel-cache/*.whl 2>/dev/null | head -20 || echo "No wheels found"
+
+      # ========================================================================
+      # IMAGE FINALIZATION AND A/B CONVERSION
+      # ========================================================================
+      # Find uncompressed image, create A/B variant, compress both, upload both
+      # This avoids the download/decompress cycle of a separate A/B job
       # Skipped for cache-only builds
-      - name: Set dynamic asset path and name
+      - name: Create A/B variant and compress images
         id: set-asset
         if: needs.rasqberry-push-version-number.outputs.build_scope != 'cache-only'
         run: |
           # Ensure we're in the right directory
           if [ ! -d "pi-gen" ]; then
             echo "Error: pi-gen directory not found in $(pwd)"
-            echo "Directory contents:"
             ls -la
             exit 1
           fi
-          cd pi-gen
-          mkdir -p ../deploy
+          mkdir -p deploy
 
-          # Find the compressed image file
-          FINAL_IMAGE=$(find deploy -name "*.img.xz" -type f | head -n 1)
+          # Find the uncompressed image file (DEPLOY_COMPRESSION=none)
+          RAW_IMAGE=$(find pi-gen/deploy -name "*.img" -type f | head -n 1)
 
-          if [ -z "$FINAL_IMAGE" ]; then
-            echo "Error: No image found in deploy directory"
+          if [ -z "$RAW_IMAGE" ]; then
+            echo "Error: No uncompressed image found in pi-gen/deploy"
+            ls -la pi-gen/deploy/ || echo "deploy directory does not exist"
             exit 1
           fi
 
-          echo "Pi-gen created: $(basename "$FINAL_IMAGE")"
+          echo "Pi-gen created: $(basename "$RAW_IMAGE")"
+          echo "Size: $(du -h "$RAW_IMAGE" | cut -f1)"
 
-          # Determine correct filename from VERSION file
-          VERSION=$(cat ../VERSION)
+          # Determine compression settings from environment (all builds use xz)
+          COMPRESS_LEVEL="${COMPRESSION_LEVEL:-1}"
+          COMPRESS_LEVEL_FALLBACK="${COMPRESSION_LEVEL_FALLBACK:-}"
+          COMPRESS_EXT="xz"
+          CONTENT_TYPE="application/x-xz"
+          echo "Compression: xz level ${COMPRESS_LEVEL}"
+          if [ -n "$COMPRESS_LEVEL_FALLBACK" ]; then
+            echo "Fallback level: ${COMPRESS_LEVEL_FALLBACK} (if image exceeds 2GB)"
+          fi
+
+          # Determine correct base filename from VERSION file
+          VERSION=$(cat VERSION)
           echo "VERSION file content: $VERSION"
 
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            # Semantic version (main branch)
-            CORRECT_FILENAME="rasqberry-${VERSION}.img.xz"
+            BASE_FILENAME="rasqberry-${VERSION}"
           elif [[ "$VERSION" =~ ^beta-([0-9]{4}-[0-9]{2}-[0-9]{2})-[0-9]{6}$ ]]; then
-            # Beta branch - date only (no time)
             BUILD_DATE="${BASH_REMATCH[1]}"
-            CORRECT_FILENAME="rasqberry-beta-${BUILD_DATE}.img.xz"
+            BASE_FILENAME="rasqberry-beta-${BUILD_DATE}"
           elif [[ "$VERSION" =~ ^(.+)-([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{6})$ ]]; then
-            # Dev branch - full timestamp
             BRANCH_NAME_FROM_VERSION="${BASH_REMATCH[1]}"
             BUILD_DATE="${BASH_REMATCH[2]}"
             BUILD_TIME="${BASH_REMATCH[3]}"
-            CORRECT_FILENAME="rasqberry-${BRANCH_NAME_FROM_VERSION}-${BUILD_DATE}-${BUILD_TIME}.img.xz"
+            BASE_FILENAME="rasqberry-${BRANCH_NAME_FROM_VERSION}-${BUILD_DATE}-${BUILD_TIME}"
           else
-            # Fallback - use whatever pi-gen created
-            CORRECT_FILENAME=$(basename "$FINAL_IMAGE")
+            BASE_FILENAME=$(basename "$RAW_IMAGE" .img)
             echo "Warning: VERSION format not recognized, using pi-gen filename"
           fi
 
-          echo "Correct filename: $CORRECT_FILENAME"
+          STANDARD_IMG="deploy/${BASE_FILENAME}.img"
+          AB_IMG="deploy/${BASE_FILENAME}-ab.img"
 
-          # Copy to deploy folder with correct filename
-          cp "$FINAL_IMAGE" "../deploy/$CORRECT_FILENAME"
+          echo "Standard image: $STANDARD_IMG"
+          echo "A/B image: $AB_IMG"
 
-          # Set outputs for upload step
-          echo "asset_path=deploy/$CORRECT_FILENAME" >> $GITHUB_OUTPUT
-          echo "asset_name=$CORRECT_FILENAME" >> $GITHUB_OUTPUT
+          # Show initial disk space
+          echo ""
+          echo "=== Disk Space Before Processing ==="
+          df -h /
 
-          # Display build information
-          echo "Built image: $CORRECT_FILENAME"
-          echo "Size: $(du -h ../deploy/$CORRECT_FILENAME | cut -f1)"
-          
+          # MOVE raw image to deploy with correct name (saves 8GB vs copy)
+          # Note: pi-gen creates files as root, so we need sudo
+          sudo mv "$RAW_IMAGE" "$STANDARD_IMG"
+          echo "Moved raw image to: $STANDARD_IMG"
+
+          # Clean up pi-gen directories to free space for A/B conversion
+          sudo rm -rf pi-gen/deploy pi-gen/work
+          echo "Cleaned up pi-gen/deploy and pi-gen/work"
+          echo ""
+          echo "=== Disk Space After Cleanup ==="
+          df -h /
+
+          # ================================================================
+          # CREATE A/B BOOT VARIANT (for ab-only and full builds)
+          # ================================================================
+          BUILD_SCOPE="${{ needs.rasqberry-push-version-number.outputs.build_scope }}"
+          if [[ "$BUILD_SCOPE" == "full" ]] || [[ "$BUILD_SCOPE" == "ab-only" ]]; then
+            echo ""
+            echo "=== Creating A/B Boot Variant ==="
+
+            # Read console configuration from pi-gen-config (already set in earlier step)
+            CONSOLE_TYPE=$(grep "^CONSOLE_TYPE=" pi-gen-config | cut -d'=' -f2)
+            BOOT_VERBOSITY=$(grep "^BOOT_VERBOSITY=" pi-gen-config | cut -d'=' -f2)
+
+            echo "Console: ${CONSOLE_TYPE}, Boot: ${BOOT_VERBOSITY}"
+
+            # Run conversion script
+            sudo CONSOLE_TYPE="${CONSOLE_TYPE}" BOOT_VERBOSITY="${BOOT_VERBOSITY}" \
+              ./stage-RQB2/08-ab-boot-support/files/convert-to-ab-boot-v3.sh \
+              "$STANDARD_IMG" \
+              "$AB_IMG"
+
+            if [ ! -f "$AB_IMG" ]; then
+              echo "Error: A/B conversion failed"
+              exit 1
+            fi
+            echo "A/B image created: $(du -h "$AB_IMG" | cut -f1)"
+
+            # Verify A/B image configuration
+            echo ""
+            echo "=== Verifying A/B Boot Configuration ==="
+
+            # Show partition layout
+            echo "Partition layout:"
+            sudo parted "$AB_IMG" print
+
+            # Mount and verify configuration files
+            AB_LOOP=$(sudo losetup -fP --show "$AB_IMG")
+            TEMP_MOUNT=$(mktemp -d)
+
+            # Check cmdline.txt in bootfs-a
+            sudo mount "${AB_LOOP}p2" "$TEMP_MOUNT"
+            echo ""
+            echo "cmdline.txt (bootfs-a):"
+            cat "$TEMP_MOUNT/cmdline.txt"
+            sudo umount "$TEMP_MOUNT"
+
+            # Check fstab in rootfs-a
+            sudo mount "${AB_LOOP}p5" "$TEMP_MOUNT"
+            echo ""
+            echo "/etc/fstab (rootfs-a):"
+            cat "$TEMP_MOUNT/etc/fstab"
+            sudo umount "$TEMP_MOUNT"
+
+            # Check config partition
+            sudo mount "${AB_LOOP}p1" "$TEMP_MOUNT"
+            echo ""
+            echo "autoboot.txt:"
+            cat "$TEMP_MOUNT/autoboot.txt"
+            sudo umount "$TEMP_MOUNT"
+
+            # Cleanup
+            rmdir "$TEMP_MOUNT"
+            sudo losetup -d "$AB_LOOP"
+            echo ""
+            echo "=== A/B Configuration Verified ==="
+          fi
+
+          # ================================================================
+          # CALCULATE METADATA AND COMPRESS IMAGES
+          # ================================================================
+          # Calculate SHA256 of uncompressed image BEFORE compression
+          # This saves ~2 minutes by avoiding re-download in JSON job
+          echo ""
+          echo "=== Calculating image metadata before compression ==="
+
+          # Calculate uncompressed size and SHA256 for standard image
+          echo "Calculating SHA256 of $(basename "$STANDARD_IMG")..."
+          EXTRACT_SIZE=$(stat -c%s "$STANDARD_IMG")
+          EXTRACT_SHA256=$(sha256sum "$STANDARD_IMG" | cut -d' ' -f1)
+          echo "  Uncompressed size: $((EXTRACT_SIZE / 1024 / 1024)) MB"
+          echo "  SHA256: $EXTRACT_SHA256"
+
+          echo ""
+          echo "=== Compressing Images with xz -${COMPRESS_LEVEL} ==="
+
+          # Define 2GB limit in bytes (2 * 1024 * 1024 * 1024)
+          MAX_SIZE_BYTES=2147483648
+
+          # Helper to run xz and handle exit code 2 (permission warning)
+          # xz returns 2 when compression succeeds but it can't set file group
+          run_xz() {
+            local XZ_EXIT
+            xz "$@" || XZ_EXIT=$?
+            if [ "${XZ_EXIT:-0}" -eq 2 ]; then
+              echo "  (ignoring xz exit code 2 - permission warning)"
+              return 0
+            fi
+            return ${XZ_EXIT:-0}
+          }
+
+          # Function to compress with fallback if exceeds 2GB
+          compress_with_fallback() {
+            local IMG="$1"
+            local LEVEL="$2"
+            local FALLBACK="$3"
+            local COMPRESSED="${IMG}.xz"
+
+            echo "Compressing $(basename "$IMG") with xz -${LEVEL}..."
+            run_xz -${LEVEL} -T0 -k "$IMG"  # -k keeps original for potential recompression
+
+            # Check size
+            local SIZE=$(stat -c%s "$COMPRESSED")
+            local SIZE_MB=$((SIZE / 1024 / 1024))
+            echo "  Compressed size: ${SIZE_MB} MB"
+
+            if [ "$SIZE" -gt "$MAX_SIZE_BYTES" ] && [ -n "$FALLBACK" ]; then
+              echo "  ⚠️ Image exceeds 2GB limit (${SIZE_MB} MB)"
+              echo "  Recompressing with xz -${FALLBACK}..."
+              rm -f "$COMPRESSED"
+              run_xz -${FALLBACK} -T0 -k "$IMG"
+              SIZE=$(stat -c%s "$COMPRESSED")
+              SIZE_MB=$((SIZE / 1024 / 1024))
+              echo "  New size: ${SIZE_MB} MB"
+
+              if [ "$SIZE" -gt "$MAX_SIZE_BYTES" ]; then
+                echo "  ⚠️ WARNING: Image still exceeds 2GB after fallback compression!"
+              else
+                echo "  ✓ Image now under 2GB limit"
+              fi
+            elif [ "$SIZE" -gt "$MAX_SIZE_BYTES" ]; then
+              echo "  ⚠️ WARNING: Image exceeds 2GB limit (no fallback configured)"
+            else
+              echo "  ✓ Image under 2GB limit"
+            fi
+
+            # Remove original uncompressed image
+            rm -f "$IMG"
+          }
+
+          # Set output filenames
+          STANDARD_COMPRESSED="deploy/${BASE_FILENAME}.img.${COMPRESS_EXT}"
+          AB_COMPRESSED="deploy/${BASE_FILENAME}-ab.img.${COMPRESS_EXT}"
+
+          # Compress images based on build scope
+          # ab-only: Only compress AB image (delete standard to save space/time)
+          # full: Compress both images
+          # standard-image: Compress only standard image
+          if [[ "$BUILD_SCOPE" == "ab-only" ]]; then
+            echo "Build scope: ab-only - compressing A/B image only"
+            # Delete standard image (not needed for ab-only)
+            rm -f "$STANDARD_IMG"
+            # Compress A/B image
+            compress_with_fallback "$AB_IMG" "$COMPRESS_LEVEL" "$COMPRESS_LEVEL_FALLBACK"
+          else
+            # Compress standard image (for full and standard-image scopes)
+            compress_with_fallback "$STANDARD_IMG" "$COMPRESS_LEVEL" "$COMPRESS_LEVEL_FALLBACK"
+            # Compress A/B image if it exists (for full scope)
+            if [ -f "$AB_IMG" ]; then
+              compress_with_fallback "$AB_IMG" "$COMPRESS_LEVEL" "$COMPRESS_LEVEL_FALLBACK"
+            fi
+          fi
+
+          echo ""
+          echo "=== Compression Complete ==="
+          if [ -f "$STANDARD_COMPRESSED" ]; then
+            echo "Standard: $STANDARD_COMPRESSED ($(du -h "$STANDARD_COMPRESSED" | cut -f1))"
+          fi
+          if [ -f "$AB_COMPRESSED" ]; then
+            echo "A/B: $AB_COMPRESSED ($(du -h "$AB_COMPRESSED" | cut -f1))"
+          fi
+
+          # Export outputs for standard image (if exists)
+          if [ -f "$STANDARD_COMPRESSED" ]; then
+            COMPRESSED_SIZE=$(stat -c%s "$STANDARD_COMPRESSED")
+            echo "asset_path=$STANDARD_COMPRESSED" >> $GITHUB_OUTPUT
+            echo "asset_name=$(basename $STANDARD_COMPRESSED)" >> $GITHUB_OUTPUT
+            echo "compressed_size=$COMPRESSED_SIZE" >> $GITHUB_OUTPUT
+          fi
+
+          # Export pre-computed metadata (used by JSON job)
+          echo "extract_sha256=$EXTRACT_SHA256" >> $GITHUB_OUTPUT
+          echo "extract_size=$EXTRACT_SIZE" >> $GITHUB_OUTPUT
+
+          # Export A/B image outputs (if exists)
+          if [ -f "$AB_COMPRESSED" ]; then
+            AB_COMPRESSED_SIZE=$(stat -c%s "$AB_COMPRESSED")
+            echo "ab_asset_path=$AB_COMPRESSED" >> $GITHUB_OUTPUT
+            echo "ab_asset_name=$(basename $AB_COMPRESSED)" >> $GITHUB_OUTPUT
+            echo "ab_compressed_size=$AB_COMPRESSED_SIZE" >> $GITHUB_OUTPUT
+            # For ab-only builds, use AB image size as primary compressed_size
+            if [[ "$BUILD_SCOPE" == "ab-only" ]]; then
+              echo "compressed_size=$AB_COMPRESSED_SIZE" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          # Always set content_type (needed by both upload steps)
+          # For ab-only builds, this is the only place it gets set
+          echo "content_type=$CONTENT_TYPE" >> $GITHUB_OUTPUT
+
           # Log cache usage summary
           if [ "${{ steps.cache-decision.outputs.use_cache }}" == "true" ]; then
+            echo ""
             echo "Build completed with base stage caching enabled"
             if [ "${{ steps.cache-base-stages.outputs.cache-hit }}" == "true" ]; then
               echo "Base stages cache hit - only custom stage-RQB2 was rebuilt"
@@ -1026,12 +1420,14 @@ jobs:
           fi
 
       # ========================================================================
-      # RELEASE ASSET UPLOAD
+      # RELEASE ASSET UPLOADS
       # ========================================================================
-      # Upload the built image to the GitHub release
-      # Skipped for cache-only builds
-      - name: Upload Release Asset
-        if: needs.rasqberry-push-version-number.outputs.build_scope != 'cache-only'
+      # Upload images to the GitHub release based on build scope
+      # ab-only: Only A/B image
+      # full: Both standard and A/B images
+      # standard-image: Only standard image
+      - name: Upload Standard Image
+        if: needs.rasqberry-push-version-number.outputs.build_scope != 'cache-only' && needs.rasqberry-push-version-number.outputs.build_scope != 'ab-only' && steps.set-asset.outputs.asset_path != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1039,171 +1435,83 @@ jobs:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ${{ steps.set-asset.outputs.asset_path }}
           asset_name: ${{ steps.set-asset.outputs.asset_name }}
-          asset_content_type: application/x-xz  # XZ compressed disk image
+          asset_content_type: ${{ steps.set-asset.outputs.content_type }}
 
-  # ============================================================================
-  # JOB 4: Build A/B Boot Image Variant
-  # ============================================================================
-  # Converts the standard image to A/B boot layout for testing
-  # Only runs when build_scope is 'full'
-  build-ab-image:
-    name: Build A/B Boot Image
-    needs: [rasqberry-push-version-number, release, build]
-    runs-on: ubuntu-latest
-    # Only build AB image when scope is 'full'
-    if: needs.rasqberry-push-version-number.outputs.build_scope == 'full'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.rasqberry-push-version-number.outputs.commit_sha }}
-
-      - name: Free up disk space
-        run: |
-          echo "=== Initial disk space ==="
-          df -h /
-
-          # Quick cleanup for image conversion (less aggressive than full build)
-          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet &
-          wait
-
-          echo "=== Final disk space ==="
-          df -h /
-
-      - name: Install required tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y parted kpartx xz-utils dosfstools e2fsprogs rsync
-
-      - name: Download and convert to A/B boot layout
-        id: convert-ab
-        env:
-          CONSOLE_TYPE: ${{ inputs.console_type || 'hdmi' }}
-          BOOT_VERBOSITY: ${{ inputs.boot_verbosity || 'splash' }}
-        run: |
-          # Read AB compression level from config
-          AB_COMPRESSION_LEVEL=$(grep "^AB_COMPRESSION_LEVEL=" pi-gen-config | cut -d'=' -f2)
-          AB_COMPRESSION_LEVEL="${AB_COMPRESSION_LEVEL:-6}"
-          echo "AB compression level: $AB_COMPRESSION_LEVEL"
-
-          # Get the asset details from the build job
-          ASSET_NAME="${{ needs.build.outputs.asset_name }}"
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref == 'refs/heads/main' && format('v{0}', needs.rasqberry-push-version-number.outputs.version_num) || needs.rasqberry-push-version-number.outputs.version_num }}/${ASSET_NAME}"
-
-          echo "Downloading standard image: $ASSET_NAME"
-          curl -L -o "$ASSET_NAME" "$DOWNLOAD_URL"
-
-          # Decompress
-          echo "Decompressing image..."
-          xz -d "$ASSET_NAME"
-
-          # Get the .img filename
-          INPUT_IMG="${ASSET_NAME%.xz}"
-          OUTPUT_IMG="${INPUT_IMG%.img}-ab.img"
-
-          echo "Converting $INPUT_IMG to A/B layout: $OUTPUT_IMG"
-          echo "Console configuration: CONSOLE_TYPE=${CONSOLE_TYPE}, BOOT_VERBOSITY=${BOOT_VERBOSITY}"
-
-          # Run the v3 conversion script (deterministic UUIDs, 16GB system partitions)
-          # Pass environment variables explicitly to sudo
-          sudo CONSOLE_TYPE="${CONSOLE_TYPE}" BOOT_VERBOSITY="${BOOT_VERBOSITY}" \
-            ./stage-RQB2/08-ab-boot-support/files/convert-to-ab-boot-v3.sh \
-            "$INPUT_IMG" \
-            "$OUTPUT_IMG"
-
-          # Verify the conversion succeeded
-          if [ ! -f "$OUTPUT_IMG" ]; then
-            echo "Error: AB conversion failed - output file not created"
-            exit 1
-          fi
-
-          # Delete input image to save disk space before compression
-          echo "Removing input image to free disk space..."
-          rm -f "$INPUT_IMG"
-          echo "Freed: $(du -h . | tail -1)"
-
-          # Show partition layout
-          echo "=== AB Image Partition Layout ==="
-          sudo parted "$OUTPUT_IMG" print
-
-          # Verify cmdline.txt and fstab configuration
-          echo ""
-          echo "=== Verifying AB Boot Configuration ==="
-          echo "Mounting AB image partitions for verification..."
-          AB_LOOP=$(sudo losetup -fP --show "$OUTPUT_IMG")
-          echo "Loop device: $AB_LOOP"
-
-          # Mount bootfs-a to check cmdline.txt
-          TEMP_MOUNT=$(mktemp -d)
-          sudo mount "${AB_LOOP}p2" "$TEMP_MOUNT"
-          echo ""
-          echo "cmdline.txt (bootfs-a):"
-          cat "$TEMP_MOUNT/cmdline.txt"
-          sudo umount "$TEMP_MOUNT"
-
-          # Mount rootfs-a to check fstab
-          sudo mount "${AB_LOOP}p5" "$TEMP_MOUNT"
-          echo ""
-          echo "/etc/fstab (rootfs-a):"
-          cat "$TEMP_MOUNT/etc/fstab"
-          sudo umount "$TEMP_MOUNT"
-
-          # Mount config partition to check autoboot.txt
-          sudo mount "${AB_LOOP}p1" "$TEMP_MOUNT"
-          echo ""
-          echo "Config partition (p1):"
-          ls -la "$TEMP_MOUNT" | grep -E "autoboot.txt|config.txt" || echo "  (marker files not found)"
-          echo ""
-          echo "autoboot.txt:"
-          cat "$TEMP_MOUNT/autoboot.txt"
-          sudo umount "$TEMP_MOUNT"
-
-          # Cleanup
-          rmdir "$TEMP_MOUNT"
-          sudo losetup -d "$AB_LOOP"
-          echo ""
-          echo "=== Configuration Verification Complete ==="
-          echo ""
-
-          # Compress AB image
-          echo "Compressing AB image with level $AB_COMPRESSION_LEVEL..."
-          # xz will try to preserve file group ownership and fail with exit code 2
-          # in GitHub Actions, but the compression succeeds. Check if .xz exists.
-          set +e
-          xz -${AB_COMPRESSION_LEVEL} -T0 "$OUTPUT_IMG"
-          xz_exit=$?
-          set -e
-
-          if [ $xz_exit -ne 0 ]; then
-            if [ $xz_exit -eq 2 ] && [ -f "${OUTPUT_IMG}.xz" ]; then
-              echo "Warning: xz reported exit code 2 (file permission warning) but compression succeeded"
-            else
-              echo "Error: xz compression failed with exit code $xz_exit"
-              exit $xz_exit
-            fi
-          fi
-
-          AB_IMG_XZ="${OUTPUT_IMG}.xz"
-
-          echo "AB image compressed: $AB_IMG_XZ"
-          echo "Size: $(du -h $AB_IMG_XZ | cut -f1)"
-
-          # Output for next step
-          echo "ab_image=$AB_IMG_XZ" >> $GITHUB_OUTPUT
-
-      - name: Upload AB image to release
+      - name: Upload A/B Image
+        if: (needs.rasqberry-push-version-number.outputs.build_scope == 'full' || needs.rasqberry-push-version-number.outputs.build_scope == 'ab-only') && steps.set-asset.outputs.ab_asset_path != ''
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ${{ steps.convert-ab.outputs.ab_image }}
-          asset_name: ${{ steps.convert-ab.outputs.ab_image }}
-          asset_content_type: application/x-xz
+          asset_path: ${{ steps.set-asset.outputs.ab_asset_path }}
+          asset_name: ${{ steps.set-asset.outputs.ab_asset_name }}
+          asset_content_type: ${{ steps.set-asset.outputs.content_type }}
+
+      # ========================================================================
+      # BUILD SUMMARY
+      # ========================================================================
+      - name: Build summary
+        if: always()
+        run: |
+          echo ""
+          echo "========================================"
+          echo "BUILD SUMMARY"
+          echo "========================================"
+          echo ""
+          echo "Build scope: ${{ needs.rasqberry-push-version-number.outputs.build_scope }}"
+          echo "Runner: ${{ runner.os }} / ${{ runner.arch }}"
+          echo ""
+
+          # Check cache status
+          echo "=== Cache Status ==="
+
+          # Base stages cache
+          if [ "${{ steps.cache-base-stages.outputs.cache-hit }}" == "true" ]; then
+            echo "Base stages cache: HIT"
+          else
+            echo "Base stages cache: MISS (built fresh)"
+          fi
+
+          # Wheel cache
+          if [ "${{ steps.cache-wheels.outputs.cache-hit }}" == "true" ]; then
+            echo "Wheel cache: HIT"
+            WHEEL_CACHE_HIT=true
+          else
+            echo "Wheel cache: MISS (downloaded during build)"
+            WHEEL_CACHE_HIT=false
+          fi
+
+          # Pip cache
+          if [ "${{ steps.cache-pip.outputs.cache-hit }}" == "true" ]; then
+            echo "Pip cache: HIT"
+          else
+            echo "Pip cache: MISS"
+          fi
+
+          echo ""
+
+          # Provide guidance if wheel cache missed
+          if [ "$WHEEL_CACHE_HIT" != "true" ] && [ "${{ steps.cache-decision.outputs.use_cache }}" == "true" ]; then
+            echo "========================================"
+            echo "TIP: Wheel cache miss detected"
+            echo "========================================"
+            echo ""
+            echo "To speed up future builds, populate the ARM64 wheel cache on main:"
+            echo ""
+            echo "  1. Go to Actions > Rasqberry Pi Image Release v2"
+            echo "  2. Click 'Run workflow'"
+            echo "  3. Select branch: main"
+            echo "  4. Set options:"
+            echo "     - build_scope: cache-only"
+            echo "  5. Run workflow"
+            echo ""
+            echo "This will populate caches that feature branches can reuse."
+            echo ""
+          fi
 
   # ============================================================================
-  # JOB 5: Generate and Upload RQB-images.json
+  # JOB 4: Generate and Upload RQB-images.json
   # ============================================================================
   # Always generates the JSON file, optionally uploads to gh-pages
   # Skipped for cache-only builds (no release to document)
@@ -1220,40 +1528,26 @@ jobs:
         with:
           fetch-depth: 0
           
-      - name: Download and calculate image metadata
+      - name: Get image metadata from build job
         id: metadata
         run: |
-          # Get the asset details from the build job
+          # Use pre-computed metadata from build job (saves ~2 minutes)
+          # Previously this step downloaded 1.9GB and streamed decompression
+
           ASSET_NAME="${{ needs.build.outputs.asset_name }}"
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref == 'refs/heads/main' && format('v{0}', needs.rasqberry-push-version-number.outputs.version_num) || needs.rasqberry-push-version-number.outputs.version_num }}/${ASSET_NAME}"
-          
-          echo "Downloading image to calculate metadata: $ASSET_NAME"
-          
-          # Download the compressed image from the release
-          curl -L -o "$ASSET_NAME" "$DOWNLOAD_URL"
-          
-          if [ ! -f "$ASSET_NAME" ]; then
-            echo "Error: Failed to download image file"
-            exit 1
-          fi
-          
-          echo "Calculating metadata using streaming decompression..."
-          
-          # Get uncompressed size from xz metadata (no extraction needed)
-          EXTRACT_SIZE=$(xz --list --robot "$ASSET_NAME" | tail -n 1 | awk '{print $5}')
-          
-          # Calculate SHA256 using streaming decompression (no disk write)
-          echo "Streaming decompression to calculate SHA256 (this may take a few minutes)..."
-          EXTRACT_SHA256=$(xz -d -c "$ASSET_NAME" | sha256sum | cut -d' ' -f1)
-          
-          # Calculate compressed image size
-          COMPRESSED_SIZE=$(stat -c%s "$ASSET_NAME")
-          
-          # Clean up downloaded file to save space
-          rm -f "$ASSET_NAME"
-          
+
+          # Get pre-computed values from build job
+          EXTRACT_SHA256="${{ needs.build.outputs.extract_sha256 }}"
+          EXTRACT_SIZE="${{ needs.build.outputs.extract_size }}"
+          COMPRESSED_SIZE="${{ needs.build.outputs.compressed_size }}"
           RELEASE_DATE=$(date +"%Y-%m-%d")
-          
+
+          echo "Using pre-computed metadata from build job (no download needed):"
+          echo "  Compressed size: $COMPRESSED_SIZE bytes ($(numfmt --to=iec-i --suffix=B $COMPRESSED_SIZE))"
+          echo "  Uncompressed size: $EXTRACT_SIZE bytes ($(numfmt --to=iec-i --suffix=B $EXTRACT_SIZE))"
+          echo "  Uncompressed SHA256: $EXTRACT_SHA256"
+
           # Output all metadata
           echo "download_url=${DOWNLOAD_URL}" >> $GITHUB_OUTPUT
           echo "compressed_size=${COMPRESSED_SIZE}" >> $GITHUB_OUTPUT
@@ -1262,172 +1556,143 @@ jobs:
           echo "release_date=${RELEASE_DATE}" >> $GITHUB_OUTPUT
           echo "version_num=${{ needs.rasqberry-push-version-number.outputs.version_num }}" >> $GITHUB_OUTPUT
           
-          # Display calculated values
-          echo "Image metadata calculated:"
-          echo "  Compressed size: $COMPRESSED_SIZE bytes ($(numfmt --to=iec-i --suffix=B $COMPRESSED_SIZE))"
-          echo "  Uncompressed size: $EXTRACT_SIZE bytes ($(numfmt --to=iec-i --suffix=B $EXTRACT_SIZE))"
-          echo "  Uncompressed SHA256: $EXTRACT_SHA256"
-          
-      - name: Determine version type
+      - name: Determine version type and stream
         id: version-type
         run: |
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
           VERSION_NUM="${{ steps.metadata.outputs.version_num }}"
-          
+
           if [[ "$BRANCH_NAME" == "main" ]]; then
             echo "type=main" >> $GITHUB_OUTPUT
+            echo "stream=stable" >> $GITHUB_OUTPUT
             echo "name=RasQberry Two (64-bit)" >> $GITHUB_OUTPUT
             echo "description=RasQberry stable release for exploring Quantum Computing and Qiskit" >> $GITHUB_OUTPUT
+            echo "tag=v${VERSION_NUM}" >> $GITHUB_OUTPUT
+            echo "release_name=rasqberry-v${VERSION_NUM}" >> $GITHUB_OUTPUT
           elif [[ "$BRANCH_NAME" == "beta" ]]; then
             echo "type=beta" >> $GITHUB_OUTPUT
+            echo "stream=beta" >> $GITHUB_OUTPUT
             echo "name=RasQberry Two Beta (64-bit)" >> $GITHUB_OUTPUT
             echo "description=RasQberry beta release with latest features (may be unstable)" >> $GITHUB_OUTPUT
+            echo "tag=${VERSION_NUM}" >> $GITHUB_OUTPUT
+            echo "release_name=rasqberry-${VERSION_NUM}" >> $GITHUB_OUTPUT
           else
             echo "type=dev" >> $GITHUB_OUTPUT
+            echo "stream=dev" >> $GITHUB_OUTPUT
             echo "name=RasQberry Two Dev (64-bit)" >> $GITHUB_OUTPUT
             echo "description=RasQberry development build with cutting-edge features (unstable)" >> $GITHUB_OUTPUT
+            echo "tag=${VERSION_NUM}" >> $GITHUB_OUTPUT
+            echo "release_name=rasqberry-${VERSION_NUM}" >> $GITHUB_OUTPUT
           fi
           
       - name: Generate RQB-images.json
         run: |
-          # Try to fetch existing JSON from gh-pages as base
-          echo "Fetching existing RQB-images.json from gh-pages..."
-          
-          # Attempt to download existing JSON from gh-pages
-          if curl -s -f "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/RQB-images.json" -o existing.json; then
-            echo "✓ Found existing JSON on gh-pages, using as base"
-            cp existing.json RQB-images.json
-          else
-            echo "ℹ No existing JSON found on gh-pages, creating fresh base"
-            cat > RQB-images.json << 'EOF'
+          # Generate single-entry RQB-images.json for THIS branch only
+          # Consolidation into multi-stream file happens in separate workflow
+
+          VERSION_TYPE="${{ steps.version-type.outputs.type }}"
+          echo "Generating single-entry RQB-images.json for ${VERSION_TYPE} stream..."
+
+          cat > RQB-images.json << EOF
           {
             "imager": {
               "latest_version": "1.8.5",
               "url": "https://www.raspberrypi.com/software/"
             },
-            "os_list": []
+            "os_list": [
+              {
+                "name": "${{ steps.version-type.outputs.name }}",
+                "description": "${{ steps.version-type.outputs.description }}",
+                "icon": "https://rasqberry.org/Artwork/RasQberry 2 Logo Cube 64x64.png",
+                "url": "${{ steps.metadata.outputs.download_url }}",
+                "extract_size": ${{ steps.metadata.outputs.extract_size }},
+                "extract_sha256": "${{ steps.metadata.outputs.extract_sha256 }}",
+                "image_download_size": ${{ steps.metadata.outputs.compressed_size }},
+                "release_date": "${{ steps.metadata.outputs.release_date }}",
+                "init_format": "systemd",
+                "devices": ["pi5-64bit", "pi4-64bit"],
+                "website": "https://rasqberry.org"
+              }
+            ]
+          }
+          EOF
+
+          echo "Generated RQB-images.json with single ${VERSION_TYPE} entry:"
+          cat RQB-images.json
+
+      - name: Generate RQB-releases.json
+        run: |
+          # RQB-releases.json tracks the latest release per stream (stable/beta/dev)
+          # This enables stable URLs for the latest release from each stream
+
+          STREAM="${{ steps.version-type.outputs.stream }}"
+          TAG="${{ steps.version-type.outputs.tag }}"
+          RELEASE_NAME="${{ steps.version-type.outputs.release_name }}"
+
+          echo "Generating RQB-releases.json for stream: $STREAM"
+
+          # Try to fetch existing RQB-releases.json from gh-pages
+          if curl -s -f "https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/RQB-releases.json" -o existing-releases.json; then
+            echo "✓ Found existing RQB-releases.json on gh-pages, using as base"
+            cp existing-releases.json RQB-releases.json
+          else
+            echo "ℹ No existing RQB-releases.json found, creating fresh file"
+            cat > RQB-releases.json << 'EOF'
+          {
+            "generated": "",
+            "streams": {}
           }
           EOF
           fi
-          
-          # Generate the new entry
-          VERSION_TYPE="${{ steps.version-type.outputs.type }}"
-          cat > new_entry.json << EOF
-          {
-            "name": "${{ steps.version-type.outputs.name }}",
-            "description": "${{ steps.version-type.outputs.description }}",
-            "icon": "https://rasqberry.org/Artwork/RasQberry 2 Logo Cube 64x64.png",
-            "url": "${{ steps.metadata.outputs.download_url }}",
-            "extract_size": ${{ steps.metadata.outputs.extract_size }},
-            "extract_sha256": "${{ steps.metadata.outputs.extract_sha256 }}",
-            "image_download_size": ${{ steps.metadata.outputs.compressed_size }},
-            "release_date": "${{ steps.metadata.outputs.release_date }}",
-            "init_format": "systemd",
-            "devices": ["pi5-64bit", "pi4-64bit"],
-            "website": "https://rasqberry.org"
-          }
-          EOF
-          
+
           # Use Python to update the JSON (handles JSON parsing properly)
           python3 << 'PYTHON_SCRIPT'
           import json
-          import sys
-          from datetime import datetime
-          
+          from datetime import datetime, timezone
+
           # Load existing JSON
-          with open('RQB-images.json', 'r') as f:
+          with open('RQB-releases.json', 'r') as f:
               data = json.load(f)
-          
-          # Load new entry
-          with open('new_entry.json', 'r') as f:
-              new_entry = json.load(f)
-          
-          version_type = "${{ steps.version-type.outputs.type }}"
-          print(f"Processing {version_type} version entry...")
-          
-          # Define mapping of version types to name patterns
-          type_patterns = {
-              "main": "RasQberry Two (64-bit)",
-              "beta": "RasQberry Two Beta (64-bit)", 
-              "dev": "RasQberry Two Dev (64-bit)"
+
+          stream = "${{ steps.version-type.outputs.stream }}"
+
+          # Create the stream entry with all metadata
+          stream_entry = {
+              "tag": "${{ steps.version-type.outputs.tag }}",
+              "name": "${{ steps.version-type.outputs.release_name }}",
+              "image_url": "${{ steps.metadata.outputs.download_url }}",
+              "release_url": "https://github.com/${{ github.repository }}/releases/tag/${{ steps.version-type.outputs.tag }}",
+              "release_date": "${{ steps.metadata.outputs.release_date }}",
+              "image_download_size": ${{ steps.metadata.outputs.compressed_size }},
+              "extract_size": ${{ steps.metadata.outputs.extract_size }},
+              "extract_sha256": "${{ steps.metadata.outputs.extract_sha256 }}"
           }
-          
-          # Remove existing entry of the same type (keep only latest per type)
-          initial_count = len(data['os_list'])
-          data['os_list'] = [entry for entry in data['os_list'] 
-                           if entry['name'] != type_patterns.get(version_type, new_entry['name'])]
-          removed_count = initial_count - len(data['os_list'])
-          
-          if removed_count > 0:
-              print(f"Removed {removed_count} existing {version_type} entry(ies)")
-          
-          # Find the right position to insert the new entry
-          # Order: main (if exists), beta (if exists), dev (if exists), then others
-          insert_position = 0
-          priority_order = ["main", "beta", "dev"]
-          current_type_priority = priority_order.index(version_type) if version_type in priority_order else 999
-          
-          for i, entry in enumerate(data['os_list']):
-              # Determine the type of this existing entry
-              entry_type = None
-              for type_name, pattern in type_patterns.items():
-                  if entry['name'] == pattern:
-                      entry_type = type_name
-                      break
-              
-              if entry_type and entry_type in priority_order:
-                  entry_priority = priority_order.index(entry_type)
-                  if current_type_priority < entry_priority:
-                      insert_position = i
-                      break
-              else:
-                  # Non-RasQberry entry, insert before it
-                  insert_position = i
-                  break
-              insert_position = i + 1
-          
-          # Insert the new entry at the calculated position
-          data['os_list'].insert(insert_position, new_entry)
-          print(f"Inserted new {version_type} entry at position {insert_position}")
-          
-          # Add official Raspberry Pi OS and Custom option if not present
-          has_raspios = any("Raspberry Pi OS" in entry['name'] for entry in data['os_list'])
-          has_custom = any("Custom" in entry.get('name', '') for entry in data['os_list'])
-          
-          if not has_raspios:
-              raspios_entry = {
-                  "name": "Raspberry Pi OS (64-bit)",
-                  "description": "A port of Debian Bookworm with the Raspberry Pi Desktop (Recommended)",
-                  "icon": "https://downloads.raspberrypi.com/raspios_armhf/Raspberry_Pi_OS_(32-bit).png",
-                  "url": "https://downloads.raspberrypi.com/raspios_arm64/images/raspios_arm64-2024-10-28/2024-10-22-raspios-bookworm-arm64.img.xz",
-                  "extract_size": 6102712320,
-                  "extract_sha256": "88093218a66cf20e8669963902a949c4c23b73309c2fc3331d09fa6ee2134417",
-                  "image_download_size": 1238664180,
-                  "release_date": "2024-10-22",
-                  "init_format": "systemd",
-                  "devices": ["pi5-64bit", "pi4-64bit"]
-              }
-              data['os_list'].append(raspios_entry)
-          
-          if not has_custom:
-              custom_entry = {
-                  "name": "Use custom image",
-                  "description": "Select a custom .img from your computer",
-                  "icon": "https://downloads.raspberrypi.com/imager/icons/folder.png"
-              }
-              data['os_list'].append(custom_entry)
-          
-          # Write updated JSON
-          with open('RQB-images.json', 'w') as f:
+
+          # Update timestamp and stream
+          data['generated'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+          if 'streams' not in data:
+              data['streams'] = {}
+
+          data['streams'][stream] = stream_entry
+
+          print(f"Updated '{stream}' stream:")
+          print(f"  Tag: {stream_entry['tag']}")
+          print(f"  Image URL: {stream_entry['image_url']}")
+
+          # Write updated JSON with pretty formatting
+          with open('RQB-releases.json', 'w') as f:
               json.dump(data, f, indent=2)
-          
-          print(f"Updated RQB-images.json with {version_type} version")
+
+          print(f"\nRQB-releases.json now contains {len(data['streams'])} stream(s): {', '.join(data['streams'].keys())}")
           PYTHON_SCRIPT
-          
-          # Clean up temporary file
-          rm -f new_entry.json
-          
-      - name: Commit JSON to current branch
+
+          echo ""
+          echo "=== Generated RQB-releases.json ==="
+          cat RQB-releases.json
+          echo ""
+
+      - name: Commit JSON files to current branch
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -1435,38 +1700,60 @@ jobs:
           # Pull latest changes to avoid conflicts
           git pull origin ${{ github.ref_name }} || echo "No remote changes to pull"
 
-          # Always commit the JSON file to current branch
-          git add RQB-images.json
-          git commit -m "Generate RQB-images.json for ${{ steps.version-type.outputs.type }} release ${{ steps.metadata.outputs.version_num }}"
+          # Commit both JSON files to current branch
+          git add RQB-images.json RQB-releases.json
+          git commit -m "Generate RQB-images.json and RQB-releases.json for ${{ steps.version-type.outputs.type }} release ${{ steps.metadata.outputs.version_num }}"
           git push origin ${{ github.ref_name }}
-          echo "Generated RQB-images.json in current branch"
+          echo "Generated RQB-images.json and RQB-releases.json in current branch"
 
-      - name: Upload RQB-images.json to release
-        uses: softprops/action-gh-release@v2.2.1
+      - name: Upload JSON files to release
+        uses: softprops/action-gh-release@v2.4.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref == 'refs/heads/main' && format('v{0}', needs.rasqberry-push-version-number.outputs.version_num) || needs.rasqberry-push-version-number.outputs.version_num }}
-          files: RQB-images.json
+          files: |
+            RQB-images.json
+            RQB-releases.json
 
-      - name: Upload JSON to gh-pages
-        if: ${{ github.event.inputs.publish_json == 'true' }}
+      # RQB-releases.json is ALWAYS pushed to gh-pages (required for cross-branch consolidation)
+      # RQB-images.json is only pushed when publish_json is true (Pi Imager compatibility)
+      - name: Upload RQB-releases.json to gh-pages (always)
         run: |
-          echo "Uploading RQB-images.json to gh-pages..."
-          
-          # Fetch and checkout gh-pages
+          echo "Uploading RQB-releases.json to gh-pages (required for stream consolidation)..."
+
+          # Fetch gh-pages branch
           git fetch origin gh-pages || echo "No gh-pages branch found"
           if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            # Save the generated file before switching branches
+            cp RQB-releases.json /tmp/RQB-releases.json
+
             git checkout gh-pages
-            
-            # Copy the generated JSON file
-            git checkout ${{ github.ref_name }} -- RQB-images.json
-            
+
+            # Copy the generated RQB-releases.json
+            cp /tmp/RQB-releases.json RQB-releases.json
+
             # Commit and push to gh-pages
-            git add RQB-images.json
-            git commit -m "Update RQB-images.json from ${{ github.ref_name }} with ${{ steps.version-type.outputs.type }} release ${{ steps.metadata.outputs.version_num }}"
+            git add RQB-releases.json
+            git commit -m "Update RQB-releases.json with ${{ steps.version-type.outputs.stream }} stream from ${{ steps.version-type.outputs.type }} release ${{ steps.metadata.outputs.version_num }}" || echo "No changes to commit"
             git push origin gh-pages
-            echo "Successfully uploaded RQB-images.json to gh-pages"
+            echo "✓ RQB-releases.json uploaded to gh-pages"
+
+            # Switch back to original branch for subsequent steps
+            git checkout ${{ github.ref_name }}
           else
-            echo "No gh-pages branch exists, skipping upload"
+            echo "⚠ No gh-pages branch exists - RQB-releases.json consolidation requires gh-pages branch"
+            echo "  Create gh-pages branch or run with publish_json=true on first build"
           fi
+
+      # Trigger consolidation workflow to merge all branches into gh-pages
+      - name: Trigger JSON consolidation workflow
+        run: |
+          echo "Triggering consolidation workflow to update gh-pages..."
+          gh workflow run consolidate-json.yaml \
+            --ref gh-pages \
+            -f trigger_source="${{ github.ref_name }}" \
+            -f trigger_type="${{ steps.version-type.outputs.type }}"
+          echo "✓ Consolidation workflow triggered"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Updates the workflow file from dev-features03 to enable cross-branch cache population on main.

### ARM64 Native Runners
- New `runner_type` input: default (arm64), x64 (QEMU fallback)
- Uses `ubuntu-24.04-arm` for native ARM64 builds (free for public repos since Jan 2025)
- ~2x faster builds without QEMU emulation overhead

### Build Scope Options
- New `build_scope` input with options:
  - `cache-only`: Build base stages and save cache, no release (for cache seeding)
  - `ab-only`: Build only A/B boot image (faster dev iterations)
  - `standard-image`: Build only standard image
  - `full`: Build both images
- Enables cross-branch cache population from main

### Workflow Cleanup
- Removed obsolete `refresh_cache` and `build_cache` inputs
- Consolidated to `build_scope: cache-only` for cache operations
- Added 'default' option to all choice inputs for consistency

### ARM64-Optimized Cleanup
- Architecture detection for disk/memory cleanup steps
- Targeted tool removal for ARM64 runners (swift, julia, miniconda, aws-cli)
- Parallel background jobs for faster cleanup

### Additional Improvements
- Build configuration summary step at start of build
- Branch-based defaults for console/boot verbosity
- Updated softprops/action-gh-release to v2.4.2
- Improved help text and error messages

## Usage: Populate Cross-Branch Cache

After merging, run workflow manually on main:
1. Go to Actions > Rasqberry Pi Image Release v2
2. Click 'Run workflow'
3. Select branch: main
4. Set `build_scope: cache-only`
5. Run workflow

This populates ARM64 caches that dev branches can reuse.

## Test plan
- [ ] Merge to main
- [ ] Run cache-only build on main with ARM64 runner
- [ ] Verify cache is saved successfully
- [ ] Run dev branch build and verify cache hit