### PR TITLE
add(config): qiskit requirements file for cache-only builds

### DIFF
--- a/RQB2-config/qiskit-requirements.txt
+++ b/RQB2-config/qiskit-requirements.txt
@@ -1,0 +1,58 @@
+# RasQberry Qiskit Requirements
+# This file defines the default Qiskit packages installed in the RasQberry image
+# Used by: rq_install_qiskit.sh and GitHub Actions pip cache
+#
+# Note: qiskit[all] is installed separately with version constraint by the script
+# Related issues: #32, #127, #149
+
+# =============================================================================
+# Core Qiskit extension packages
+# =============================================================================
+qiskit-ibm-runtime
+qiskit-aer
+
+# =============================================================================
+# Application modules
+# =============================================================================
+qiskit-optimization
+qiskit-machine-learning
+qiskit-nature
+qiskit-finance
+qiskit-experiments
+
+# =============================================================================
+# Jupyter and visualization
+# =============================================================================
+jupyterlab
+notebook
+ipywidgets
+plotly
+
+# =============================================================================
+# Scientific computing
+# =============================================================================
+matplotlib
+numpy
+scipy
+pandas
+sympy
+seaborn
+pillow
+
+# =============================================================================
+# Hardware integration (RasQberry-specific)
+# =============================================================================
+adafruit-blinka
+adafruit-circuitpython-neopixel
+# Note: pygobject is provided via system package symlink (see 03-install-qiskit/00-run-chroot.sh)
+netifaces  # For IP display service (08-ip-display)
+sense-hat
+sense-emu
+python-dotenv
+
+# =============================================================================
+# Automation and testing
+# =============================================================================
+selenium
+webdriver-manager
+celluloid


### PR DESCRIPTION
## Summary

Adds the qiskit requirements file to main branch so cache-only builds can download the complete set of ARM64 wheels.

## Problem

The cache-only workflow on main failed because `RQB2-config/qiskit-requirements.txt` doesn't exist on main branch. The wheel download step needs this file to know which packages to cache.

## Changes

- Add `RQB2-config/qiskit-requirements.txt` (copied from dev-features03)

## Test plan

- [ ] Merge this PR
- [ ] Trigger cache-only build on main
- [ ] Verify wheel download succeeds