### PR TITLE
Add Fun with Quantum family footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -9,6 +9,20 @@ export function Footer() {
                 <p style={{ fontSize: '0.875rem', marginTop: '1rem', opacity: 0.8 }}>
                     <a href="/newsletter" style={{ color: 'inherit', textDecoration: 'underline' }}>Subscribe to our newsletter</a> for occasional updates.
                 </p>
+                <p style={{ fontSize: '0.75rem', marginTop: '1rem', opacity: 0.8, fontFamily: 'monospace', letterSpacing: '0.05em' }}>
+                    GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.
+                </p>
+                <p style={{ fontSize: '0.875rem', marginTop: '0.5rem', opacity: 0.8 }}>
+                    Part of the Fun with Quantum family:{' '}
+                    <a href="https://fun-with-quantum.org" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Fun with Quantum</a> ·{' '}
+                    <a href="https://rasqberry.one" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>RasQberry One</a> ·{' '}
+                    <a href="https://quantego.org" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Quantego</a> ·{' '}
+                    <a href="https://qutie.org" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Qutie</a> ·{' '}
+                    <a href="https://qoffee-maker.org" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Qoffee-Maker</a>
+                </p>
+                <p style={{ fontSize: '0.875rem', marginTop: '0.5rem', opacity: 0.8 }}>
+                    Open source, built by Jan-R. Lahmann and the RasQberry community.
+                </p>
                 <p style={{ fontSize: '0.875rem', marginTop: '0.5rem', opacity: 0.8 }}>
                     RasQberry is an independent educational project and is not affiliated with, endorsed by, or sponsored by IBM Corporation. IBM®, IBM Quantum®, Qiskit®, and IBM Quantum System Two are trademarks of International Business Machines Corporation. This project creates an educational tool inspired by IBM&apos;s quantum computing systems for teaching purposes.
                     <br />


### PR DESCRIPTION
Adds the shared "Fun with Quantum family" footer for cross-traffic across the family sites, matching the footers already live on fun-with-quantum.org and qutie.org.

## Changes
- `src/components/Footer/index.tsx`: adds three lines to the existing footer, using the same inline-style conventions already in the component:
  - the family tagline ("GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.") in small monospace
  - "Part of the Fun with Quantum family:" with links to fun-with-quantum.org, rasqberry.one, quantego.org, qutie.org, and qoffee-maker.org (this site itself is excluded)
  - "Open source, built by Jan-R. Lahmann and the RasQberry community."

## Verification
- `npm ci && npm run build` passes; all 24 static pages generate.
- Confirmed the family links render in the built HTML (`.next/server/app/index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)