### PR TITLE
Add Umami analytics (shared family property)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,12 @@ export default function RootLayout({
         {children}
         <Footer />
         <Script
+          defer
+          src="https://cloud.umami.is/script.js"
+          data-website-id="97f347ac-e7ba-4be3-b26f-ab4b328bdbf2"
+          data-domains="rasqberry.org"
+        />
+        <Script
           id="sender-net"
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
Adds cookieless Umami Cloud analytics via a `next/script` tag in the app router root layout, alongside the existing sender.net script.

- Shared website ID across the Fun with Quantum family; per-site hostname filtering happens in the Umami dashboard.
- No cookies, so no consent banner is needed.
- `data-domains="rasqberry.org"` keeps localhost/preview traffic out of the stats.

Verified: `npm ci && npm run build` completes successfully, and the Umami script tag is present in the generated static HTML (e.g. `.next/server/app/index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)